### PR TITLE
Update and fix TailwindCSS

### DIFF
--- a/components/Cart.tsx
+++ b/components/Cart.tsx
@@ -9,7 +9,7 @@ const Cart = ({ children }: { children: ReactNode }) => (
     stripe={getStripe()}
     currency={config.CURRENCY}
   >
-    <>{children}</>
+    <div className="space-x-4 flex flex-auto">{children}</div>
   </CartProvider>
 );
 

--- a/components/CartSummary.tsx
+++ b/components/CartSummary.tsx
@@ -39,13 +39,13 @@ const CartSummary = () => {
 
       <div className="mb-2 flex">
         <button
-          className="w-1/2 mr-2 mt-2 min-h-full text-xs bg-green hover:bg-darkgreen text-white font-bold rounded"
+          className="w-1/2 mr-2 mt-2 min-h-full text-xs bg-greenblue-light hover:bg-greenblue-dark text-white font-bold rounded"
           type="submit"
           disabled={cartEmpty || loading}>
           Checkout
         </button>
         <button
-          className="w-1/2 mt-2 ml-2 min-h-full text-xs border-grey bg-gold hover:bg-cheesyyellow hover:text-white font-bold rounded"
+          className="w-1/2 mt-2 ml-2 min-h-full text-xs border-grey bg-gold hover:bg-yellow-cheesy hover:text-white font-bold rounded"
           type="button"
           onClick={clearCart}>
           Clear Cart

--- a/components/CartSummary.tsx
+++ b/components/CartSummary.tsx
@@ -27,7 +27,7 @@ const CartSummary = () => {
   };
 
   return (
-    <form onSubmit={handleCheckout}>
+    <form className="sticky-bottom px-8" onSubmit={handleCheckout}>
       <h2>Cart summary</h2>
       {/* This is where we'll render our cart */}
       <p suppressHydrationWarning>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -29,16 +29,6 @@ const Layout = ({children, title = "TypeScript Next.js Stripe Example"}: Props) 
       </header>
       {children}
     </div>
-    <div className="banner">
-      <span>
-        This site is open-sourced.
-        {" View the code on "}
-        <a href="https://github.com/open-sauced/swag" target="_blank" rel="noopener noreferrer">
-          GitHub
-        </a>
-        .
-      </span>
-    </div>
   </>
 );
 

--- a/components/Products.tsx
+++ b/components/Products.tsx
@@ -25,12 +25,12 @@ const Products = () => {
           </div>
           <div className="mb-2 flex">
             <button
-              className="w-1/2 m-2 min-h-full text-xs bg-green hover:bg-darkgreen text-white font-bold py-2 px-4 rounded"
+              className="w-1/2 m-2 min-h-full text-xs bg-greenblue-light hover:bg-greenblue-dark text-white font-bold py-2 px-4 rounded"
               onClick={() => addItem(product)}>
               Add to cart
             </button>
             <button
-              className="w-1/2 m-2 min-h-full text-xs bg-gold hover:bg-cheesyyellow text-white font-bold py-2 px-4 rounded"
+              className="w-1/2 m-2 min-h-full text-xs bg-gold hover:bg-yellow-cheesy text-white font-bold py-2 px-4 rounded"
               onClick={() => removeItem(product.sku)}>
               Remove
             </button>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^13.1.2",
     "@types/react": "^16.9.17",
     "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.6.2",
+    "tailwindcss": "^1.7.5",
     "typescript": "^3.7.4"
   }
 }

--- a/pages/gradient-test.tsx
+++ b/pages/gradient-test.tsx
@@ -1,0 +1,39 @@
+import { NextPage } from 'next';
+import Layout from '../components/Layout';
+
+const GradientPage: NextPage = () => {
+  return (
+    <Layout title="Home | Next.js + TypeScript Example">
+      <div>
+        <header className="mb-16">
+          <h1 className="text-5xl font-bold">
+            <span className="bg-clip-text text-transparent bg-gradient-to-r from-teal-400 to-blue-500">
+              Greetings from Tailwind v1.7.
+            </span>
+          </h1>
+        </header>
+        <div className="h-24 mb-20 bg-gradient-to-r from-orange-400 from-gold via-red-saucy to-red-dark">
+
+        </div>
+        <section>
+          <div className="flex space-x-4 mb-8">
+            <button type="button" className="bg-white hover:bg-gray-100 text-gray-700 font-semibold py-2 px-4 border border-solid border-gray-400 rounded shadow">
+              Regular
+            </button>
+            <button type="button" className="bg-gradient-to-r from-teal-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-4 py-2 rounded shadow">
+              Hover
+            </button>
+            <button type="button" className="bg-gradient-to-r from-teal-400 to-blue-500 focus:from-pink-500 focus:to-orange-500 text-white font-semibold px-4 py-2 rounded shadow">
+              Focus
+            </button>
+          </div>
+          <small className="block text-gray-600">
+            Button <span className="bg-gray-200 text-gray-700 p-1">font-size</span> comes from <span className="bg-gray-200 text-gray-700 p-1">styles.css</span>
+          </small>
+        </section>
+      </div>
+    </Layout>
+  );
+};
+
+export default GradientPage;

--- a/pages/use-shopping-cart.tsx
+++ b/pages/use-shopping-cart.tsx
@@ -9,7 +9,11 @@ const DonatePage: NextPage = () => {
   return (
     <Layout title="Shopping Cart | Next.js + TypeScript Example">
       <div className="page-container">
-        <h1>Shopping Cart</h1>
+        <h1>
+          <span className="bg-clip-text text-transparent bg-gradient-to-r from-gold via-red-saucy to-red-dark">
+            Shopping Cart
+          </span>
+        </h1>
         <p>
           Powered by the <a href="https://use-shopping-cart.netlify.app/">use-shopping-cart</a> React hooks library.
         </p>

--- a/pages/use-shopping-cart.tsx
+++ b/pages/use-shopping-cart.tsx
@@ -14,8 +14,8 @@ const DonatePage: NextPage = () => {
           Powered by the <a href="https://use-shopping-cart.netlify.app/">use-shopping-cart</a> React hooks library.
         </p>
         <Cart>
-          <CartSummary />
           <Products />
+          <CartSummary />
         </Cart>
       </div>
     </Layout>

--- a/styles.css
+++ b/styles.css
@@ -39,9 +39,16 @@ body {
   flex-direction: row;
 }
 
+.sticky-bottom {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 1rem;
+  align-self: flex-end;
+}
+
 .page-container {
   padding-bottom: 60px;
-  max-width: var(--page-width-max);
+  /* max-width: var(--page-width-max); */
 }
 
 h1 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,29 +1,60 @@
+const { colors: { red, yellow, blue, orange } } = require('tailwindcss/defaultTheme');
+
 module.exports = {
   purge: [],
   theme: {
-    colors: {
-      accent: "#faeace",
-      background: "#fffbf5",
-      saucyred: "#d95c41",
-      cheesyyellow: "#f6d809",
-      offwhite: "#fbfbfb",
-      lightestgrey: "#e6e6e6",
-      lightergrey: "#bcbcbc",
-      lightgrey: "#8b8b8b",
-      backgroundgrey: "#2F372E",
-      grey: "#313d3e",
-      darkgrey: "#171c1d",
-      darkestgrey: "#0c0e0e",
-      gold: "#f6bc00",
-      orange: "#fe9d68",
-      blue: "#4d9abf",
-      green: "#00c7b7",
-      darkgreen: "#03b1a3",
-      red: "#fb6d77",
-      darkred: "#fa3946",
+    extend: {
+      colors: {
+        background: "#fffbf5",
+        offwhite: "#fbfbfb",
+        accent: "#faeace",
+
+        gold: "#f6bc00",
+
+        greenblue: {
+          light: "#00c7b7",
+          dark: "#03b1a3",
+        },
+
+        red: {
+          ...red,
+          base: "#fb6d77",
+          dark: "#fa3946",
+          saucy: "#d95c41",
+        },
+
+        yellow: {
+          ...yellow,
+          cheesy: "#f6d809",
+        },
+
+        grey: {
+          100: "#fafafa",
+          200: "#f2f2f2",
+          300: "#e6e6e6",
+          400: "#bcbcbc",
+          500: "#8b8b8b",
+          600: "#2F372E",
+          700: "#313d3e",
+          800: "#171c1d",
+          900: "#0c0e0e",
+        },
+
+        blue: {
+          ...blue,
+          base: "#4d9abf",
+        },
+
+        orange: {
+          ...orange,
+          450: "#fe9d68",
+        }
+      },
     },
-    extend: {},
   },
   variants: {},
   plugins: [],
+  future: {
+    removeDeprecatedGapUtilities: true,
+  },
 };


### PR DESCRIPTION
### Why is this PR needed?

This PR updates tailwindcss to latest (`v1.7.5`), and, fixes the gradients issue caused by overwriting the default color palette and not [extending it], thus not being able to test out the new gradient classes. The extended colors have also been fixed to match tailwind's naming scheme - `200` instead of `lighter` and so on, for most of the colors anyway, the old green colors were added as `greenblue-light|dark` respectively since that seemed like a more fitting name, take a look at the config to see the new extended version. 👍

Have fun messing around with the new gradients, I'm sure it's going to be awesome. 😎

### Included in PR.

- Update tailwindcss to `v1.7.5`
- Fix tailwindcss config not extending default palette.
- Fix button classes not matching new config.
- Add `/gradients-test` endpoint to test gradients

[extending it]: https://tailwindcss.com/docs/customizing-colors#extending-the-default-palette